### PR TITLE
rsync support for Capistrano ssh_options :proxy

### DIFF
--- a/lib/capistrano/supply_drop/rsync.rb
+++ b/lib/capistrano/supply_drop/rsync.rb
@@ -64,7 +64,7 @@ module SupplyDrop
           when :password                then nil # not supported
           when :port                    then "-p #{value.to_i}"
           when :properties              then nil # not applicable
-          when :proxy                   then nil # not applicable
+          when :proxy                   then opt('ProxyCommand', value.command_line)
           when :rekey_blocks_limit      then nil # not supported
           when :rekey_limit             then opt('RekeyLimit', reverse_interpret_size(value))
           when :rekey_packet_limit      then nil # not supported


### PR DESCRIPTION
Who says :proxy is not applicable to rsync?
